### PR TITLE
Make catalog and dataset endpoints accessible for DCAT

### DIFF
--- a/ckanext/noanonaccess/plugin.py
+++ b/ckanext/noanonaccess/plugin.py
@@ -15,6 +15,8 @@ class AuthMiddleware(object):
     def __call__(self, environ, start_response):
         # Get the dcat_access variable from the config object
         dcat_access = config.get('ckanext.noanonaccess.allow_dcat')
+        # List of extensions to be made accessible if dcat_access is True
+        ext = ['.jsonld','.xml','.ttl','.n3']
         # we putting only UI behind login so API paths should remain accessible
         # also, allow access to dataset download and uploaded files
         if '/api/' in environ['PATH_INFO'] or '/datastore/dump/' in environ['PATH_INFO']:
@@ -26,8 +28,8 @@ class AuthMiddleware(object):
         elif 'repoze.who.identity' in environ or self._get_user_for_apikey(environ):
             # if logged in via browser cookies or API key, all pages accessible
             return self.app(environ,start_response)
-        elif dcat_access and (environ['PATH_INFO'].startswith('/dataset') 
-                          or environ['PATH_INFO'].startswith('/catalog')):
+        elif dcat_access and (environ['PATH_INFO'].endswith(tuple(ext))
+                          or 'catalog' in environ['PATH_INFO']):
             # If dcat_acess is enabled in the .env file make dataset and 
             # catalog pages accessible
             return self.app(environ,start_response)

--- a/ckanext/noanonaccess/plugin.py
+++ b/ckanext/noanonaccess/plugin.py
@@ -17,6 +17,12 @@ class AuthMiddleware(object):
         dcat_access = config.get('ckanext.noanonaccess.allow_dcat')
         # List of extensions to be made accessible if dcat_access is True
         ext = ['.jsonld','.xml','.ttl','.n3']
+        # List of catalog endpoints                                      
+        catalog_endpoint = config.get('ckanext.dcat.catalog_endpoint')
+        catalog_endpoints = ['/catalog']                                 
+        if catalog_endpoint:                  
+            catalog_endpoint = catalog_endpoint.split('/{_format}')      
+            catalog_endpoints.append(catalog_endpoint[0])
         # we putting only UI behind login so API paths should remain accessible
         # also, allow access to dataset download and uploaded files
         if '/api/' in environ['PATH_INFO'] or '/datastore/dump/' in environ['PATH_INFO']:
@@ -29,7 +35,7 @@ class AuthMiddleware(object):
             # if logged in via browser cookies or API key, all pages accessible
             return self.app(environ,start_response)
         elif dcat_access and (environ['PATH_INFO'].endswith(tuple(ext))
-                          or 'catalog' in environ['PATH_INFO']):
+                          or environ['PATH_INFO'].startswith(tuple(catalog_endpoints))):
             # If dcat_acess is enabled in the .env file make dataset and 
             # catalog pages accessible
             return self.app(environ,start_response)

--- a/ckanext/noanonaccess/plugin.py
+++ b/ckanext/noanonaccess/plugin.py
@@ -13,6 +13,8 @@ class AuthMiddleware(object):
     def __init__(self, app, app_conf):
         self.app = app
     def __call__(self, environ, start_response):
+        # Get the dcat_access variable from the config object
+        dcat_access = config.get('ckanext.noanonaccess.allow_dcat')
         # we putting only UI behind login so API paths should remain accessible
         # also, allow access to dataset download and uploaded files
         if '/api/' in environ['PATH_INFO'] or '/datastore/dump/' in environ['PATH_INFO']:
@@ -23,6 +25,11 @@ class AuthMiddleware(object):
             return self.app(environ,start_response)
         elif 'repoze.who.identity' in environ or self._get_user_for_apikey(environ):
             # if logged in via browser cookies or API key, all pages accessible
+            return self.app(environ,start_response)
+        elif dcat_access and (environ['PATH_INFO'].startswith('/dataset') 
+                          or environ['PATH_INFO'].startswith('/catalog')):
+            # If dcat_acess is enabled in the .env file make dataset and 
+            # catalog pages accessible
             return self.app(environ,start_response)
         else:
             # otherwise only login/reset are accessible


### PR DESCRIPTION
This PR provides a fix for https://gitlab.com/datopian/core/support/-/issues/209

## Need

Client wants the DCAT related endpoints ([details for endpoints](https://extensions.ckan.org/extension/dcat/#rdf-dcat-endpoints) ) for dataset and catalog to be accessible

## FIX

* This PR adds a variable `dcat_access = config.get('ckanext.noanonaccess.allow_dcat')` which when set true makes all the below mentioned file extensions accessible for anon.
  * `.jsonld`
  * `.xml`
  * `.ttl`
  * `.n3`
* Also enables anon to access [catalog endpoints](https://extensions.ckan.org/extension/dcat/#catalog-endpoint)


**NOTE:** `CKANEXT.NOANONACCESS.ALLOW_DCAT=True` must be set in the `.env` file in order to make the endpoints accessible for anon